### PR TITLE
Remove silly json exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ cabal.sandbox.config
 cabal.project.local
 .HTF/
 .ghc.environment.*
-level0*/firstapp_db.db
+level0*/*app_db.db
 level0*/result

--- a/level05/src/FirstApp/Conf/File.hs
+++ b/level05/src/FirstApp/Conf/File.hs
@@ -29,45 +29,6 @@ import           FirstApp.Types             (ConfigError,
 -- need. The package we're using is the ``aeson`` package to parse some JSON and
 -- we'll pick the bits off the Object.
 
--- Complete the helper function that will be used to retrieve values off the
--- JSON object.
-
--- | fromJsonObjWithKey
--- >>> let (Just obj) = ( Aeson.decode "{\"foo\":\"Susan\"}" ) :: Maybe Aeson.Object
---
--- >>> fromJsonObjWithKey "foo" (id :: Text -> Text) obj
--- Last {getLast = Just "Susan"}
---
--- >>> fromJsonObjWithKey "foo" id obj
--- Last {getLast = Nothing}
---
-fromJsonObjWithKey
-  :: FromJSON a
-  => Text
-  -> (a -> b)
-  -> Object
-  -> Last b
-fromJsonObjWithKey =
-  error "fromJsonObjWithKey not implemented"
-
--- |----
--- | You will need to update these tests when you've completed the following functions!
--- | The 'undefined' in these tests needs to be replaced with their respective Error constructors.
--- |----
-
--- | decodeObj
--- >>> decodeObj ""
--- Left (undefined "Error in $: not enough input")
---
--- >>> decodeObj "{\"bar\":33}"
--- Right (fromList [("bar",Number 33.0)])
---
-decodeObj
-  :: ByteString
-  -> Either ConfigError Object
-decodeObj =
-  error "decodeObj not implemented"
-
 -- | Update these tests when you've completed this function.
 --
 -- | readConfFile
@@ -82,10 +43,8 @@ readConfFile
 readConfFile =
   error "readConfFile not implemented"
 
--- Construct the function that will take a ``FilePath``, read it in and attempt
--- to decode it as a valid JSON object, using the ``aeson`` package. Then pull
--- specific keys off this object and construct our ``PartialConf``. Using the
--- function we wrote above to assist in pulling items off the object.
+-- Construct the function that will take a ``FilePath``, read it in, decode it,
+-- and construct our ``PartialConf``.
 parseJSONConfigFile
   :: FilePath
   -> IO ( Either ConfigError PartialConf )

--- a/level05/src/FirstApp/Types.hs
+++ b/level05/src/FirstApp/Types.hs
@@ -248,3 +248,15 @@ instance Monoid PartialConf where
     { pcPort       = error "pcPort mappend not implemented"
     , pcDBFilePath = error "pcDBFilePath mappend not implemented"
     }
+
+-- When it comes to reading the configuration options from the command-line, we
+-- use the 'optparse-applicative' package. This part of the exercise has already
+-- been completed for you, feel free to have a look through the 'CommandLine'
+-- module and see how it works.
+--
+-- For reading the configuration from the file, we're going to use the aeson
+-- library to handle the parsing and decoding for us. In order to do this, we
+-- have to tell aeson how to go about converting the JSON into our PartialConf
+-- data structure.
+instance FromJSON PartialConf where
+  parseJSON = error "parseJSON for PartialConf not implemented yet."

--- a/level05/src/FirstApp/Types.hs
+++ b/level05/src/FirstApp/Types.hs
@@ -38,7 +38,7 @@ import           Data.List                          (stripPrefix)
 import           Data.Maybe                         (fromMaybe)
 import           Data.Time                          (UTCTime)
 
-import           Data.Aeson                         (ToJSON)
+import           Data.Aeson                         (FromJSON (..), ToJSON)
 import qualified Data.Aeson                         as A
 import qualified Data.Aeson.Types                   as A
 

--- a/level06/src/FirstApp/Conf/File.hs
+++ b/level06/src/FirstApp/Conf/File.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module FirstApp.Conf.File where
 
 import           Data.ByteString.Lazy       (ByteString)
@@ -16,68 +15,19 @@ import           Data.Aeson                 (FromJSON, Object, (.:))
 import qualified Data.Aeson                 as Aeson
 import qualified Data.Aeson.Types           as Aeson
 
-import           FirstApp.Types             (ConfigError (ConfigFileReadError, JSONDecodeError),
-                                             DBFilePath (..),
-                                             PartialConf (PartialConf),
-                                             Port (..))
+import           FirstApp.Types             (ConfigError (..), PartialConf)
+
 -- Doctest setup section
 -- $setup
 -- >>> :set -XOverloadedStrings
-
--- | File Parsing
-
--- We're trying to avoid complications when selecting a configuration file
--- package from Hackage. We'll use an encoding that you are probably familiar
--- with, for better or worse, and write a small parser to pull out the bits we
--- need. The package we're using is the ``aeson`` package to parse some JSON and
--- we'll pick the bits off the Object.
-
--- Complete the helper function that will be used to retrieve values off the
--- JSON object.
-
--- | fromJsonObjWithKey
--- >>> let (Just obj) = ( Aeson.decode "{\"foo\":\"Susan\"}" ) :: Maybe Aeson.Object
---
--- >>> fromJsonObjWithKey "foo" (id :: Text -> Text) obj
--- Last {getLast = Just "Susan"}
---
--- >>> fromJsonObjWithKey "foo" id obj
--- Last {getLast = Nothing}
---
-fromJsonObjWithKey
-  :: FromJSON a
-  => Text
-  -> (a -> b)
-  -> Object
-  -> Last b
-fromJsonObjWithKey k c o =
-  Last $ c <$> Aeson.parseMaybe (.: k) o
-
--- |----
--- | You will need to update these tests when you've completed the following functions!
--- | The 'undefined' in these tests needs to be replaced with their respective Error constructors.
--- |----
-
--- | decodeObj
--- >>> decodeObj ""
--- Left (undefined "Error in $: not enough input")
---
--- >>> decodeObj "{\"bar\":33}"
--- Right (fromList [("bar",Number 33.0)])
---
-decodeObj
-  :: ByteString
-  -> Either ConfigError Object
-decodeObj =
-  first JSONDecodeError . Aeson.eitherDecode
 
 -- | Update these tests when you've completed this function.
 --
 -- | readConfFile
 -- >>> readConfFile "badFileName.no"
--- Left (undefined "badFileName.no: openBinaryFile: does not exist (No such file or directory)")
+-- Left (ConfigFileReadError badFileName.no: openBinaryFile: does not exist (No such file or directory))
 -- >>> readConfFile "test.json"
--- Right "{\n  \"foo\": 33\n}\n"
+-- Right "{\"foo\":33}\n"
 --
 readConfFile
   :: FilePath
@@ -85,20 +35,11 @@ readConfFile
 readConfFile fp =
   first ConfigFileReadError <$> try (LBS.readFile fp)
 
--- Construct the function that will take a ``FilePath``, read it in and attempt
--- to decode it as a valid JSON object, using the ``aeson`` package. Then pull
--- specific keys off this object and construct our ``PartialConf``. Using the
--- function we wrote above to assist in pulling items off the object.
+-- Construct the function that will take a ``FilePath``, read it in, decode it,
+-- and construct our ``PartialConf``.
 parseJSONConfigFile
   :: FilePath
   -> IO ( Either ConfigError PartialConf )
 parseJSONConfigFile fp =
-  fmap toPartialConf . ( decodeObj =<< ) <$> readConfFile fp
-  where
-    toPartialConf
-      :: Aeson.Object
-      -> PartialConf
-    toPartialConf cObj = PartialConf
-      ( fromJsonObjWithKey "port" Port cObj )
-      ( fromJsonObjWithKey "dbFilePath" DBFilePath cObj )
+  (first JSONDecodeError . Aeson.eitherDecode =<<) <$> readConfFile fp
 

--- a/level06/src/FirstApp/Types.hs
+++ b/level06/src/FirstApp/Types.hs
@@ -23,7 +23,7 @@ module FirstApp.Types
   , confPortToWai
   ) where
 
-import System.IO.Error (IOError)
+import           System.IO.Error                    (IOError)
 
 import           GHC.Generics                       (Generic)
 import           GHC.Word                           (Word16)
@@ -33,9 +33,10 @@ import           Data.Text                          (Text)
 
 import           Data.List                          (stripPrefix)
 import           Data.Maybe                         (fromMaybe)
-import           Data.Monoid                        (Last, (<>))
+import           Data.Monoid                        (Last (Last), (<>))
 
-import           Data.Aeson                         (ToJSON)
+import           Data.Aeson                         (FromJSON (..), ToJSON,
+                                                     (.:?))
 import qualified Data.Aeson                         as A
 import qualified Data.Aeson.Types                   as A
 
@@ -252,6 +253,23 @@ instance Monoid PartialConf where
     { pcPort       = pcPort a <> pcPort b
     , pcDBFilePath = pcDBFilePath a <> pcDBFilePath b
     }
+
+-- When it comes to reading the configuration options from the command-line, we
+-- use the 'optparse-applicative' package. This part of the exercise has already
+-- been completed for you, feel free to have a look through the 'CommandLine'
+-- module and see how it works.
+--
+-- For reading the configuration from the file, we're going to use the aeson
+-- library to handle the parsing and decoding for us. In order to do this, we
+-- have to tell aeson how to go about converting the JSON into our PartialConf
+-- data structure.
+instance FromJSON PartialConf where
+  parseJSON = A.withObject "PartialConf" $ \o -> PartialConf
+    <$> parseToLast "port" Port o
+    <*> parseToLast "dbFilePath" DBFilePath o
+    where
+      parseToLast k c o =
+        Last . fmap c <$> o .:? k
 
 -- We have a data type to simplify passing around the information we need to run
 -- our database queries. This also allows things to change over time without

--- a/level07/src/FirstApp/Conf/File.hs
+++ b/level07/src/FirstApp/Conf/File.hs
@@ -1,83 +1,27 @@
-{-# LANGUAGE OverloadedStrings #-}
 module FirstApp.Conf.File where
 
 import           Data.ByteString.Lazy       (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
-import           Data.Text                  (Text)
-
 import           Data.Bifunctor             (first)
-import           Data.Monoid                (Last (Last))
 
 import           Control.Exception          (try)
 
-import           Data.Aeson                 (FromJSON, Object, (.:))
-
 import qualified Data.Aeson                 as Aeson
-import qualified Data.Aeson.Types           as Aeson
 
-import           FirstApp.Types             (ConfigError (ConfigFileReadError, JSONDecodeError),
-                                             DBFilePath (..),
-                                             PartialConf (PartialConf),
-                                             Port (..))
+import           FirstApp.Types             (ConfigError (..), PartialConf)
+
 -- Doctest setup section
 -- $setup
 -- >>> :set -XOverloadedStrings
-
--- | File Parsing
-
--- We're trying to avoid complications when selecting a configuration file
--- package from Hackage. We'll use an encoding that you are probably familiar
--- with, for better or worse, and write a small parser to pull out the bits we
--- need. The package we're using is the ``aeson`` package to parse some JSON and
--- we'll pick the bits off the Object.
-
--- Complete the helper function that will be used to retrieve values off the
--- JSON object.
-
--- | fromJsonObjWithKey
--- >>> let (Just obj) = ( Aeson.decode "{\"foo\":\"Susan\"}" ) :: Maybe Aeson.Object
---
--- >>> fromJsonObjWithKey "foo" (id :: Text -> Text) obj
--- Last {getLast = Just "Susan"}
---
--- >>> fromJsonObjWithKey "foo" id obj
--- Last {getLast = Nothing}
---
-fromJsonObjWithKey
-  :: FromJSON a
-  => Text
-  -> (a -> b)
-  -> Object
-  -> Last b
-fromJsonObjWithKey k c o =
-  Last $ c <$> Aeson.parseMaybe (.: k) o
-
--- |----
--- | You will need to update these tests when you've completed the following functions!
--- | The 'undefined' in these tests needs to be replaced with their respective Error constructors.
--- |----
-
--- | decodeObj
--- >>> decodeObj ""
--- Left (undefined "Error in $: not enough input")
---
--- >>> decodeObj "{\"bar\":33}"
--- Right (fromList [("bar",Number 33.0)])
---
-decodeObj
-  :: ByteString
-  -> Either ConfigError Object
-decodeObj =
-  first JSONDecodeError . Aeson.eitherDecode
 
 -- | Update these tests when you've completed this function.
 --
 -- | readConfFile
 -- >>> readConfFile "badFileName.no"
--- Left (undefined "badFileName.no: openBinaryFile: does not exist (No such file or directory)")
+-- Left (ConfigFileReadError badFileName.no: openBinaryFile: does not exist (No such file or directory))
 -- >>> readConfFile "test.json"
--- Right "{\n  \"foo\": 33\n}\n"
+-- Right "{\"foo\":33}\n"
 --
 readConfFile
   :: FilePath
@@ -85,19 +29,11 @@ readConfFile
 readConfFile fp =
   first ConfigFileReadError <$> try (LBS.readFile fp)
 
--- Construct the function that will take a ``FilePath``, read it in and attempt
--- to decode it as a valid JSON object, using the ``aeson`` package. Then pull
--- specific keys off this object and construct our ``PartialConf``. Using the
--- function we wrote above to assist in pulling items off the object.
+-- Construct the function that will take a ``FilePath``, read it in, decode it,
+-- and construct our ``PartialConf``.
 parseJSONConfigFile
   :: FilePath
   -> IO ( Either ConfigError PartialConf )
 parseJSONConfigFile fp =
-  fmap toPartialConf . ( decodeObj =<< ) <$> readConfFile fp
-  where
-    toPartialConf
-      :: Aeson.Object
-      -> PartialConf
-    toPartialConf cObj = PartialConf
-      ( fromJsonObjWithKey "port" Port cObj )
-      ( fromJsonObjWithKey "dbFilePath" DBFilePath cObj )
+  (first JSONDecodeError . Aeson.eitherDecode =<<) <$> readConfFile fp
+

--- a/level07/src/FirstApp/Types.hs
+++ b/level07/src/FirstApp/Types.hs
@@ -33,9 +33,9 @@ import           Data.Text                          (Text)
 
 import           Data.List                          (stripPrefix)
 import           Data.Maybe                         (fromMaybe)
-import           Data.Monoid                        (Last, (<>))
+import           Data.Monoid                        (Last (..), (<>))
 
-import           Data.Aeson                         (ToJSON)
+import           Data.Aeson                         (ToJSON, FromJSON (..), (.:?))
 import qualified Data.Aeson                         as A
 import qualified Data.Aeson.Types                   as A
 
@@ -44,7 +44,7 @@ import           Data.Time                          (UTCTime)
 import           Database.SQLite.Simple             (Connection)
 import           Database.SQLite.SimpleErrors.Types (SQLiteResponse)
 
-import           FirstApp.DB.Types                  (DbComment (dbCommentComment, dbCommentId, dbCommentTime, dbCommentTopic))
+import           FirstApp.DB.Types                  (DbComment (..))
 import           FirstApp.Error                     (Error (..))
 
 newtype CommentId = CommentId Int
@@ -245,6 +245,23 @@ instance Monoid PartialConf where
     { pcPort       = pcPort a <> pcPort b
     , pcDBFilePath = pcDBFilePath a <> pcDBFilePath b
     }
+
+-- When it comes to reading the configuration options from the command-line, we
+-- use the 'optparse-applicative' package. This part of the exercise has already
+-- been completed for you, feel free to have a look through the 'CommandLine'
+-- module and see how it works.
+--
+-- For reading the configuration from the file, we're going to use the aeson
+-- library to handle the parsing and decoding for us. In order to do this, we
+-- have to tell aeson how to go about converting the JSON into our PartialConf
+-- data structure.
+instance FromJSON PartialConf where
+  parseJSON = A.withObject "PartialConf" $ \o -> PartialConf
+    <$> parseToLast "port" Port o
+    <*> parseToLast "dbFilePath" DBFilePath o
+    where
+      parseToLast k c o =
+        Last . fmap c <$> o .:? k
 
 -- We have a data type to simplify passing around the information we need to run
 -- our database queries. This also allows things to change over time without


### PR DESCRIPTION
The initial ``fromJsonObjWithKey`` exercise turned out to be a bit silly and not quite the "haddock diving" experience I had envisioned.

This change has students writing a ``FromJSON`` typeclass instance for the ``PartialConf`` type. This seemed to require a change in the doctests for the file loading function which reverts an earlier PR. I haven't drilled into if this difference is due to doctest version differences.

Wording probably still needs work.