### PR TITLE
Relaxing version bounds for hspec-wai, adding upper bound.

### DIFF
--- a/level03/level03.cabal
+++ b/level03/level03.cabal
@@ -109,5 +109,5 @@ test-suite level03-tests
                       , wai == 3.2.*
                       , wai-extra == 3.0.*
                       , hspec == 2.4.*
-                      , hspec-wai == 0.8.*
+                      , hspec-wai >= 0.8 && < 0.10
                       , bytestring == 0.10.*

--- a/level04/level04.cabal
+++ b/level04/level04.cabal
@@ -114,7 +114,7 @@ test-suite level04-tests
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
                      , hspec == 2.4.*
-                     , hspec-wai == 0.8.*
+                     , hspec-wai >= 0.8 && < 0.10
                      , bytestring == 0.10.*
 
 test-suite doctests

--- a/level05/level05.cabal
+++ b/level05/level05.cabal
@@ -109,7 +109,7 @@ test-suite level05-tests
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
                      , hspec == 2.4.*
-                     , hspec-wai == 0.8.*
+                     , hspec-wai >= 0.8 && < 0.10
                      , bytestring == 0.10.*
 test-suite doctests
   -- Base language which the package is written in.

--- a/level06/level06.cabal
+++ b/level06/level06.cabal
@@ -119,7 +119,7 @@ test-suite level06-tests
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
                      , hspec == 2.4.*
-                     , hspec-wai == 0.8.*
+                     , hspec-wai >= 0.8 && < 0.10
                      , bytestring == 0.10.*
 
 test-suite doctests

--- a/level07/level07.cabal
+++ b/level07/level07.cabal
@@ -118,7 +118,7 @@ test-suite level07-tests
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
                      , hspec == 2.4.*
-                     , hspec-wai == 0.8.*
+                     , hspec-wai >= 0.8 && < 0.10
                      , bytestring == 0.10.*
                      , text == 1.2.*
                      , mtl == 2.2.*


### PR DESCRIPTION
Recommended fix for #9 

Requires stack testing to be certain.

Issue required to add `stack` builds to CI 