### PR TITLE
Update to stackage LTS 10 (GHC 8.2.2)

### DIFF
--- a/level01/stack.yaml
+++ b/level01/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.21
+resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/level02/stack.yaml
+++ b/level02/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.21
+resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/level03/level03.cabal
+++ b/level03/level03.cabal
@@ -109,5 +109,5 @@ test-suite level03-tests
                       , wai == 3.2.*
                       , wai-extra == 3.0.*
                       , hspec == 2.4.*
-                      , hspec-wai == 0.8.*
+                      , hspec-wai == 0.9.*
                       , bytestring == 0.10.*

--- a/level03/stack.yaml
+++ b/level03/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.21
+resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/level04/level04.cabal
+++ b/level04/level04.cabal
@@ -72,7 +72,7 @@ library
                      , http-types == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
-                     , optparse-applicative == 0.13.*
+                     , optparse-applicative == 0.14.*
                      , aeson == 1.*
                      , mtl == 2.2.*
                      , time >= 1.4 && <= 1.9
@@ -114,7 +114,7 @@ test-suite level04-tests
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
                      , hspec == 2.4.*
-                     , hspec-wai == 0.8.*
+                     , hspec-wai == 0.9.*
                      , bytestring == 0.10.*
 
 test-suite doctests

--- a/level04/stack.yaml
+++ b/level04/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.21
+resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/level05/level05.cabal
+++ b/level05/level05.cabal
@@ -72,7 +72,7 @@ library
                      , http-types == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
-                     , optparse-applicative == 0.13.*
+                     , optparse-applicative == 0.14.*
                      , aeson == 1.*
                      , time >= 1.4 && <= 1.9
                      , sqlite-simple == 0.4.*
@@ -109,7 +109,7 @@ test-suite level05-tests
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
                      , hspec == 2.4.*
-                     , hspec-wai == 0.8.*
+                     , hspec-wai == 0.9.*
                      , bytestring == 0.10.*
 test-suite doctests
   -- Base language which the package is written in.

--- a/level05/stack.yaml
+++ b/level05/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.21
+resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/level06/level06.cabal
+++ b/level06/level06.cabal
@@ -75,7 +75,7 @@ library
                      , http-types == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
-                     , optparse-applicative == 0.13.*
+                     , optparse-applicative == 0.14.*
                      , aeson == 1.*
                      , mtl == 2.2.*
                      , time >= 1.4 && <= 1.9
@@ -119,7 +119,7 @@ test-suite level06-tests
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
                      , hspec == 2.4.*
-                     , hspec-wai == 0.8.*
+                     , hspec-wai == 0.9.*
                      , bytestring == 0.10.*
 
 test-suite doctests

--- a/level06/stack.yaml
+++ b/level06/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.21
+resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/level07/level07.cabal
+++ b/level07/level07.cabal
@@ -76,7 +76,7 @@ library
                      , http-types == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
-                     , optparse-applicative == 0.13.*
+                     , optparse-applicative == 0.14.*
                      , aeson == 1.*
                      , mtl == 2.2.*
                      , time >= 1.4 && <= 1.9
@@ -118,7 +118,7 @@ test-suite level07-tests
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
                      , hspec == 2.4.*
-                     , hspec-wai == 0.8.*
+                     , hspec-wai == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
                      , mtl == 2.2.*

--- a/level07/stack.yaml
+++ b/level07/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.21
+resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Includes some version bumps required for the stackage version.

This is desirable because:

- It's nice to be working with GHC 8.2 over GHC 8.0 for the stack people
- Some dev tools like intero don't handle a ghc version mismatch. eg. Intero version GHC 8.2 seems to only work on 8.2 projects. Although there may be another work around I'm not aware of.