### PR TITLE
Remove reference to appconfig.json in level04

### DIFF
--- a/level04/src/FirstApp/Main.hs
+++ b/level04/src/FirstApp/Main.hs
@@ -56,7 +56,7 @@ runApp = error "runApp needs re-implementing"
 -- 2) Attempt to initialise the database.
 -- 3) Combine the results into a tuple
 --
--- The filename for our application config is: "appconfig.json"
+-- Our application configuration is defined in Conf.hs
 --
 prepareAppReqs
   :: IO ( Either StartUpError DB.FirstAppDB )


### PR DESCRIPTION
Level04 does not have a configuration stored in `appconfig.json`. This commit clarifies where the configuration is defined, which also helps guide how to use/extract it.