### PR TITLE
Add missing dependencies to level05.nix

### DIFF
--- a/level05/level05.nix
+++ b/level05/level05.nix
@@ -1,5 +1,6 @@
-{ mkDerivation, aeson, base, bytestring, doctest, http-types
-, optparse-applicative, stdenv, text, wai, warp, semigroups
+{ mkDerivation, aeson, base, bytestring, doctest, hspec, hspec-wai
+, http-types, mtl, optparse-applicative, sqlite-simple, semigroups
+, sqlite-simple-errors, stdenv, text, time, wai, wai-extra, warp
 }:
 mkDerivation {
   pname = "level05";
@@ -8,12 +9,12 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson base bytestring http-types optparse-applicative text wai warp
-    semigroups
+    aeson base bytestring http-types mtl optparse-applicative
+    sqlite-simple sqlite-simple-errors text time wai warp semigroups
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    base doctest
+    base bytestring doctest hspec hspec-wai wai wai-extra
   ];
   description = "Simplest of web apps";
   license = stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
Problem:
> nix-shell
> cabal test

fails during build with the error
> cabal: Encountered missing dependencies:
> hspec >=2.2 && <3.0, hspec-wai >=0.6 && <0.10, wai-extra ==3.0.*

Cause:
Missed dependencies in level05.nix

Fix:
Just copy level04.nix definition into level05