### PR TITLE
Fix pthread-related linking failure with stack

### DIFF
--- a/level03/stack.yaml
+++ b/level03/stack.yaml
@@ -17,6 +17,9 @@
 #  location: "./custom-snapshot.yaml"
 resolver: lts-10.4
 
+ghc-options:
+  '$everything': -threaded
+
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #

--- a/level04/stack.yaml
+++ b/level04/stack.yaml
@@ -17,6 +17,9 @@
 #  location: "./custom-snapshot.yaml"
 resolver: lts-10.4
 
+ghc-options:
+  '$everything': -threaded
+
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #

--- a/level05/stack.yaml
+++ b/level05/stack.yaml
@@ -17,6 +17,9 @@
 #  location: "./custom-snapshot.yaml"
 resolver: lts-10.4
 
+ghc-options:
+  '$everything': -threaded
+
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #

--- a/level06/stack.yaml
+++ b/level06/stack.yaml
@@ -17,6 +17,9 @@
 #  location: "./custom-snapshot.yaml"
 resolver: lts-10.4
 
+ghc-options:
+  '$everything': -threaded
+
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #

--- a/level07/stack.yaml
+++ b/level07/stack.yaml
@@ -17,6 +17,9 @@
 #  location: "./custom-snapshot.yaml"
 resolver: lts-10.4
 
+ghc-options:
+  '$everything': -threaded
+
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #


### PR DESCRIPTION
Problem:
Both stack build and stack test fail with undefined references to
pthread symbols.

Fix:
Add extra -threaded ghc option to stack configuration file.

It's unclear to me why exactly cabal build works and stack build fails.
Relevant github issues from other projects are:
https://github.com/jgm/pandoc/issues/4130
https://github.com/commercialhaskell/stack/issues/3807