### PR TITLE
Travis changes & Version Bumps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,6 +178,7 @@ script:
       do
         cd $dir
         echo "Processing $dir"
+        travis_retry cabal update
         PKGVER=$(cabal info . | awk '{print $2;exit}')
 
         if [ $CABALVER != "2.0" ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,9 +183,10 @@ script:
           echo "Processing $dir"
           travis_retry cabal update
           PKGVER=$(cabal info . | awk '{print $2;exit}')
-
         
+          cabal sandbox init
           cabal configure --enable-tests --ghc-options -O0
+          cabal install --only-dependencies
           cabal build
       
           cd $ORIGDIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,28 +174,26 @@ script:
     cabal)
 
       ORIGDIR=$(pwd)
-      for dir in $PACKAGES
-      do
-        cd $dir
-        echo "Processing $dir"
-        travis_retry cabal update
-        PKGVER=$(cabal info . | awk '{print $2;exit}')
 
-        if [ $CABALVER != "2.0" ]
-        then
-          for l in $(ls -d1 level*)
-          do
-            cd $l
-            cabal configure --enable-tests --ghc-options -O0
-            cabal build
-            cd ..
-          done
-        else
-          cabal new-configure --project-file="cabal.project" --enable-tests --ghc-options -O0
-          cabal new-build --project-file="cabal.project" all
-        fi
-        cd $ORIGDIR
-      done
+      if [ $CABALVER != "2.0" ]
+      then
+        for dir in $PACKAGES
+        do
+          cd $dir
+          echo "Processing $dir"
+          travis_retry cabal update
+          PKGVER=$(cabal info . | awk '{print $2;exit}')
+
+        
+          cabal configure --enable-tests --ghc-options -O0
+          cabal build
+      
+          cd $ORIGDIR
+        done
+      else
+        cabal new-configure --project-file="cabal.project" --enable-tests --ghc-options -O0
+        cabal new-build --project-file="cabal.project" all
+      fi
       ;;
   esac
   set +ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ matrix:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis
-  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.10.3"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    addons: {apt: {packages: [cabal-install-2.0,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
-    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [cabal-install-2.0,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.2.2"
     addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -179,7 +179,7 @@ script:
       then
 
         cabal sandbox init
-        
+
         for dir in $PACKAGES
         do
           cd $dir

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,6 +177,9 @@ script:
 
       if [ $CABALVER != "2.0" ]
       then
+
+        cabal sandbox init
+        
         for dir in $PACKAGES
         do
           cd $dir
@@ -184,7 +187,6 @@ script:
           travis_retry cabal update
           PKGVER=$(cabal info . | awk '{print $2;exit}')
         
-          cabal sandbox init
           cabal install --only-dependencies --enable-tests
           cabal configure --enable-tests --ghc-options -O0
           cabal build

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,7 +185,7 @@ script:
           PKGVER=$(cabal info . | awk '{print $2;exit}')
         
           cabal sandbox init
-          cabal install --only-dependencies
+          cabal install --only-dependencies --enable-tests
           cabal configure --enable-tests --ghc-options -O0
           cabal build
       

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,7 @@ install:
 
 script:
 - |
-  set -x
+  set -ex
   case "$BUILD" in
     stack)
       stack --no-terminal $ARGS build --no-run-benchmarks --haddock --no-haddock-deps
@@ -179,12 +179,25 @@ script:
         cd $dir
         echo "Processing $dir"
         PKGVER=$(cabal info . | awk '{print $2;exit}')
-        SRC_TGZ=$PKGVER.tar.gz
-        cd dist
-        tar zxfv "$SRC_TGZ"
-        cd "$PKGVER"
-        cabal new-configure --project-file="cabal.project" --enable-tests --ghc-options -O0
-        cabal new-build --project-file="cabal.project" all
+
+        if [ $CABALVER != "2.0" ]
+        then
+          SRC_TGZ=$PKGVER.tar.gz
+          cd dist
+          tar zxfv "$SRC_TGZ"
+          cd "$PKGVER"
+
+          for l in $(ls -d1 level*)
+          do
+            cd $l
+            cabal configure --enable-tests --ghc-options -O0
+            cabal build
+            cd ..
+          done
+        else
+          cabal new-configure --project-file="cabal.project" --enable-tests --ghc-options -O0
+          cabal new-build --project-file="cabal.project" all
+        fi
         cd $ORIGDIR
       done
       ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,11 +183,6 @@ script:
 
         if [ $CABALVER != "2.0" ]
         then
-          SRC_TGZ=$PKGVER.tar.gz
-          cd dist
-          tar zxfv "$SRC_TGZ"
-          cd "$PKGVER"
-
           for l in $(ls -d1 level*)
           do
             cd $l

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,8 +185,8 @@ script:
           PKGVER=$(cabal info . | awk '{print $2;exit}')
         
           cabal sandbox init
-          cabal configure --enable-tests --ghc-options -O0
           cabal install --only-dependencies
+          cabal configure --enable-tests --ghc-options -O0
           cabal build
       
           cd $ORIGDIR

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 <img src="https://i.imgur.com/0h9dFhl.png" height="400" width="640" />
 
-## * Beta Release *
-
 This is a brand new course, so there are going to be rough edges. We invite you to submit issues or
 pull requests if you find errors or have suggestions on how to improve it.
 

--- a/level01/level01.cabal
+++ b/level01/level01.cabal
@@ -60,7 +60,7 @@ library
                        -ferror-spans
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , wai == 3.2.*
                      , warp == 3.2.*
                      , http-types == 0.9.*
@@ -82,7 +82,7 @@ executable level01-exe
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , level01
 
   -- Directories containing source files.

--- a/level02/level02.cabal
+++ b/level02/level02.cabal
@@ -61,7 +61,7 @@ library
                        -ferror-spans
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , wai == 3.2.*
                      , warp == 3.2.*
                      , http-types == 0.9.*
@@ -86,7 +86,7 @@ executable level02-exe
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , level02
 
   -- Directories containing source files.

--- a/level03/level03.cabal
+++ b/level03/level03.cabal
@@ -104,7 +104,7 @@ test-suite level03-tests
    type:                exitcode-stdio-1.0
    hs-source-dirs:      tests
    main-is:             Test.hs
-   build-depends:       base >= 4.7 && <=4.12
+   build-depends:       base >= 4.7 && <4.12
                       , level03
                       , wai == 3.2.*
                       , wai-extra == 3.0.*

--- a/level03/level03.cabal
+++ b/level03/level03.cabal
@@ -63,7 +63,7 @@ library
                        -ferror-spans
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , wai == 3.2.*
                      , warp == 3.2.*
                      , http-types == 0.9.*
@@ -87,7 +87,7 @@ executable level03-exe
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , level03
 
   -- Directories containing source files.
@@ -104,7 +104,7 @@ test-suite level03-tests
    type:                exitcode-stdio-1.0
    hs-source-dirs:      tests
    main-is:             Test.hs
-   build-depends:       base >= 4.7 && <=4.11
+   build-depends:       base >= 4.7 && <=4.12
                       , level03
                       , wai == 3.2.*
                       , wai-extra == 3.0.*

--- a/level04/level04.cabal
+++ b/level04/level04.cabal
@@ -128,5 +128,5 @@ test-suite doctests
   main-is:             doctests.hs
   hs-source-dirs:      tests
   build-depends:       base
-                     , doctest >= 0.11 && < 0.14
+                     , doctest >= 0.11 && <= 0.15
                      , semigroups >= 0.18

--- a/level04/level04.cabal
+++ b/level04/level04.cabal
@@ -75,10 +75,10 @@ library
                      , http-types == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
-                     , optparse-applicative >= 0.13 && <= 0.15
+                     , optparse-applicative >= 0.13 && < 0.15
                      , aeson == 1.*
                      , mtl == 2.2.*
-                     , time >= 1.4 && <= 1.9
+                     , time >= 1.4 && < 1.10
                      , sqlite-simple == 0.4.*
                      , sqlite-simple-errors == 0.6.*
                      , semigroups >= 0.18
@@ -112,7 +112,7 @@ test-suite level04-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base >= 4.7 && <=4.12
+  build-depends:       base >= 4.7 && <4.12
                      , level04
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
@@ -128,5 +128,5 @@ test-suite doctests
   main-is:             doctests.hs
   hs-source-dirs:      tests
   build-depends:       base
-                     , doctest >= 0.11 && <= 0.15
+                     , doctest >= 0.11 && < 0.16
                      , semigroups >= 0.18

--- a/level04/level04.cabal
+++ b/level04/level04.cabal
@@ -69,7 +69,7 @@ library
                        -ferror-spans
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , wai == 3.2.*
                      , warp == 3.2.*
                      , http-types == 0.9.*
@@ -101,7 +101,7 @@ executable level04-exe
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , level04
 
   -- Base language which the package is written in.
@@ -112,7 +112,7 @@ test-suite level04-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base >= 4.7 && <=4.11
+  build-depends:       base >= 4.7 && <=4.12
                      , level04
                      , wai == 3.2.*
                      , wai-extra == 3.0.*

--- a/level05/level05.cabal
+++ b/level05/level05.cabal
@@ -75,9 +75,9 @@ library
                      , http-types == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
-                     , optparse-applicative >= 0.13 && <= 0.15
+                     , optparse-applicative >= 0.13 && < 0.15
                      , aeson == 1.*
-                     , time >= 1.4 && <= 1.9
+                     , time >= 1.4 && < 1.10
                      , sqlite-simple == 0.4.*
                      , sqlite-simple-errors == 0.6.*
                      , semigroups >= 0.18
@@ -107,7 +107,7 @@ test-suite level05-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base >= 4.7 && <=4.12
+  build-depends:       base >= 4.7 && <4.12
                      , level05
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
@@ -123,4 +123,4 @@ test-suite doctests
   hs-source-dirs:      tests
   build-depends:       base
                      , level05
-                     , doctest >= 0.11 && <= 0.15
+                     , doctest >= 0.11 && < 0.16

--- a/level05/level05.cabal
+++ b/level05/level05.cabal
@@ -69,7 +69,7 @@ library
                        -ferror-spans
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , wai == 3.2.*
                      , warp == 3.2.*
                      , http-types == 0.9.*
@@ -93,7 +93,7 @@ executable level05-exe
   main-is:             Main.hs
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , level05
 
   -- Directories containing source files.
@@ -107,7 +107,7 @@ test-suite level05-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base >= 4.7 && <=4.11
+  build-depends:       base >= 4.7 && <=4.12
                      , level05
                      , wai == 3.2.*
                      , wai-extra == 3.0.*

--- a/level05/level05.cabal
+++ b/level05/level05.cabal
@@ -123,4 +123,4 @@ test-suite doctests
   hs-source-dirs:      tests
   build-depends:       base
                      , level05
-                     , doctest >= 0.11 && < 0.14
+                     , doctest >= 0.11 && <= 0.15

--- a/level06/level06.cabal
+++ b/level06/level06.cabal
@@ -78,10 +78,10 @@ library
                      , http-types == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
-                     , optparse-applicative >= 0.13 && <= 0.15
+                     , optparse-applicative >= 0.13 && < 0.15
                      , aeson == 1.*
                      , mtl == 2.2.*
-                     , time >= 1.4 && <= 1.9
+                     , time >= 1.4 && < 1.10
                      , sqlite-simple == 0.4.*
                      , sqlite-simple-errors == 0.6.*
                      , semigroups >= 0.18
@@ -116,7 +116,7 @@ test-suite level06-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base >= 4.7 && <=4.12
+  build-depends:       base >= 4.7 && <4.12
                      , level06
                      , mtl == 2.2.*
                      , wai == 3.2.*
@@ -133,4 +133,4 @@ test-suite doctests
   main-is:             doctests.hs
   hs-source-dirs:      tests
   build-depends:       base
-                     , doctest >= 0.11 && <= 0.15
+                     , doctest >= 0.11 && < 0.16

--- a/level06/level06.cabal
+++ b/level06/level06.cabal
@@ -72,7 +72,7 @@ library
                        -ferror-spans
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , wai == 3.2.*
                      , warp == 3.2.*
                      , http-types == 0.9.*
@@ -105,7 +105,7 @@ executable level06-exe
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , level06
 
   -- Base language which the package is written in.
@@ -116,7 +116,7 @@ test-suite level06-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base >= 4.7 && <=4.11
+  build-depends:       base >= 4.7 && <=4.12
                      , level06
                      , mtl == 2.2.*
                      , wai == 3.2.*

--- a/level06/level06.cabal
+++ b/level06/level06.cabal
@@ -133,4 +133,4 @@ test-suite doctests
   main-is:             doctests.hs
   hs-source-dirs:      tests
   build-depends:       base
-                     , doctest >= 0.11 && < 0.14
+                     , doctest >= 0.11 && <= 0.15

--- a/level07/level07.cabal
+++ b/level07/level07.cabal
@@ -78,10 +78,10 @@ library
                      , http-types == 0.9.*
                      , bytestring == 0.10.*
                      , text == 1.2.*
-                     , optparse-applicative >= 0.13 && <= 0.15
+                     , optparse-applicative >= 0.13 && < 0.15
                      , aeson == 1.*
                      , mtl == 2.2.*
-                     , time >= 1.4 && <= 1.9
+                     , time >= 1.4 && < 1.10
                      , sqlite-simple == 0.4.*
                      , sqlite-simple-errors == 0.6.*
                      , semigroups >= 0.18
@@ -115,7 +115,7 @@ test-suite level07-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base >= 4.7 && <=4.12
+  build-depends:       base >= 4.7 && <4.12
                      , level07
                      , wai == 3.2.*
                      , wai-extra == 3.0.*
@@ -133,4 +133,4 @@ test-suite doctests
   main-is:             doctests.hs
   hs-source-dirs:      tests
   build-depends:       base
-                     , doctest >= 0.11 && <= 0.15
+                     , doctest >= 0.11 && < 0.16

--- a/level07/level07.cabal
+++ b/level07/level07.cabal
@@ -72,7 +72,7 @@ library
                        -ferror-spans
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , wai == 3.2.*
                      , warp == 3.2.*
                      , http-types == 0.9.*
@@ -104,7 +104,7 @@ executable level07-exe
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.11
+  build-depends:       base >=4.7 && <4.12
                      , level07
 
   -- Base language which the package is written in.
@@ -115,7 +115,7 @@ test-suite level07-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base >= 4.7 && <=4.11
+  build-depends:       base >= 4.7 && <=4.12
                      , level07
                      , wai == 3.2.*
                      , wai-extra == 3.0.*

--- a/level07/level07.cabal
+++ b/level07/level07.cabal
@@ -133,4 +133,4 @@ test-suite doctests
   main-is:             doctests.hs
   hs-source-dirs:      tests
   build-depends:       base
-                     , doctest >= 0.11 && < 0.14
+                     , doctest >= 0.11 && <= 0.15


### PR DESCRIPTION
Improvements to the TravisCI configuration, plus a few version bumps for base and other packages so that we can support GHC 8.4.1.

GHC 8.4.1 is considered an acceptable failure in the configuration, for the time being. Until we nail it all down.