### PR TITLE
Update Instructions for Level04 DBComment

### DIFF
--- a/src/Level04/DB/Types.hs
+++ b/src/Level04/DB/Types.hs
@@ -13,7 +13,7 @@ import           Database.SQLite.Simple.FromRow (FromRow (fromRow), field)
 
 -- Complete in the DbComment type below so it is a record type that matches the
 -- Comment type, but without the newtype wrappers for each value. To get started,
--- just copy the new definition for the `Comment` type from FirstApp.Types.
+-- just copy the new definition for the `Comment` type from Level04.Types.
 data DBComment = DBComment
   -- NB: Haskell does not allow duplicate field names for records so the field
   -- names for this type will have to be slightly different


### PR DESCRIPTION
This references `FirstApp.Types` which I do not see anymore but I infer would have been our first app that we built which was in the current Level04. This updates the comment in `Level04.DB.Types` which references this to `Level04.Types` so it is clear which section is intended to be returned to.