### PR TITLE
Fixes for typos and instructions

### DIFF
--- a/src/Level04/Conf.hs
+++ b/src/Level04/Conf.hs
@@ -10,7 +10,7 @@ data Conf = Conf
   { dbFilePath :: FilePath
   }
 
--- A aimple default that we could just inline this right where we need it. But
+-- A simple default that we could just inline this right where we need it. But
 -- types are so cheap that we can easily prepare ourselves for "doing the right
 -- thing".
 firstAppConfig :: Conf

--- a/src/Level04/README.md
+++ b/src/Level04/README.md
@@ -43,7 +43,7 @@ traverse :: (Applicative f, Traversable t) => (a -> f b) -> t a -> f (t b)
 ```
 
 This is very useful when you want to perform an action on every element of a
-list, but that action will return the new result in a some ``Applicative``
+list, but that action will return the new result in an ``Applicative``
 context.
 
 To help build some intuition for how this function can be useful, write out

--- a/src/Level04/Types.hs
+++ b/src/Level04/Types.hs
@@ -59,8 +59,7 @@ data Comment = Comment
   }
   deriving ( Show, Generic )
 
--- Strip the prefix (which may fail if the prefix isn't present), fall
--- back to the original label if need be.
+-- Strip the prefix, or fall back to the original label if prefix not present.
 
 -- | modFieldLabel
 -- >>> modFieldLabel "commentId"

--- a/src/Level05/AppM.hs
+++ b/src/Level05/AppM.hs
@@ -19,7 +19,7 @@ import           Data.Bifunctor         (first)
 -- To do this we will create a newtype `AppM` that is a shorthand way of
 -- describing the return type of a function that may contain an error.
 --
--- Our `AppM` type will work in the same manner as the Functor/Applicative/Monad 
+-- Our `AppM` type will work in the same manner as the Functor/Applicative/Monad
 -- instances for Either, with functions being applied to the Right value and
 -- everything been ignored if a Left value is encountered, returning that Left
 -- value. With the added bonus of allowing us to perform `IO` actions!
@@ -38,7 +38,7 @@ import           Data.Bifunctor         (first)
 --   either (pure . Left) needsAButMightFail aE
 --   where
 --     mightFail :: IO (Either Error Int)
---     alsoMightFail :: Int -> IO (Either Error Value)
+--     needsAButMightFail :: Int -> IO (Either Error Value)
 --
 -- We can wrap our functions with AppM and we can work directly with the
 -- values we expect to appear on the happy path, knowing that if the sad path is

--- a/src/Level05/DB.hs
+++ b/src/Level05/DB.hs
@@ -70,7 +70,7 @@ runDB
   -> IO a
   -> AppM b
 runDB =
-  error "Copy your completed 'runDB' and refactor to match the new type signature"
+  error "Write 'runDB' to match the type signature"
 
 getComments
   :: FirstAppDB

--- a/src/Level06/Core.hs
+++ b/src/Level06/Core.hs
@@ -130,19 +130,6 @@ handleRequest
   -> RqType
   -> AppM Response
 handleRequest db rqType =
-  -- Now that we're operating within the context of our AppM, which is a
-  -- ReaderT, we're able to access the values stored in the Env.
-  --
-  -- Two functions that allow us to access the data stored in our ReaderT are:
-  -- ask :: MonadReader r m => m r
-  -- &
-  -- asks :: MonadReader r m => (r -> a) -> m a
-  --
-  -- We will use ``asks`` here as we only want the FirstAppDB, so...
-  -- > envDb      :: Env -> FirstAppDB
-  -- > AppM       :: ReaderT Env IO a
-  -- > asks       :: (Env -> a) -> AppM a
-  -- > asks envDb :: AppM FirstAppDB
   case rqType of
     -- Exercise for later: Could this be generalised to clean up the repetition ?
     AddRq t c -> resp200 PlainText "Success" <$ DB.addCommentToTopic db t c


### PR DESCRIPTION
I came across a few typos in the course notes, and some of the instructions didn't make sense, so I suggested some modifications.