### PR TITLE
Change instructions to use 'new-run'

### DIFF
--- a/src/Level01/README.md
+++ b/src/Level01/README.md
@@ -18,7 +18,7 @@ To run the application:
 
 ```bash
 # With Cabal
-$ cabal run level01-exe
+$ cabal new-run level01-exe
 
 # With Stack
 $ stack exec level01-exe

--- a/src/Level02/README.md
+++ b/src/Level02/README.md
@@ -44,7 +44,7 @@ The starting point for this exercise is the ``src/Level02/Types.hs``.
 
 ```bash
 # Using cabal
-$ cabal run level02-exe
+$ cabal new-run level02-exe
 
 # Using stack
 $ stack exec level02-exe


### PR DESCRIPTION
The Level01 and Level02 ReadMe's say to execute `cabal run level01-exe` to run but I think we need to use `new-run`. Both ReadMe's are updated in this PR.