### PR TITLE
Update the pinned nixpkgs, upgrade pkgs.

### DIFF
--- a/applied-fp-course.cabal
+++ b/applied-fp-course.cabal
@@ -124,7 +124,7 @@ library
                      , semigroups == 0.18.*
                      , transformers >= 0.4 && < 0.6
                      , lens >= 4.15 && < 4.18 
-                     , waargonaut >= 0.4.2 && < 0.5
+                     , waargonaut >= 0.6 && < 0.7
                      , attoparsec >= 0.13 && < 0.15
 
   -- Directories containing source files.

--- a/course-overlays.nix
+++ b/course-overlays.nix
@@ -1,0 +1,19 @@
+let
+  sources = {
+    tasty-wai = import ./nix/tasty-wai.nix;
+    waarg = import ./nix/waargonaut.nix;
+  };
+
+  waarg-deps = import "${sources.waarg}/waargonaut-deps.nix";
+
+  course = self: super: {
+    haskellPackages = super.haskellPackages.override (old: {
+      overrides = super.lib.composeExtensions (old.overrides or (_: _: {})) (hself: hsuper: {
+        tasty-wai = hself.callCabal2nix "tasty-wai" sources.tasty-wai {};
+        waargonaut = hself.callCabal2nix "waargonaut" sources.waarg {};
+      });
+    });
+  };
+in
+  [ waarg-deps course ]
+  

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,7 @@
-{ nixpkgs ? import <nixpkgs> {}
+{ nixpkgs ? import ./nix/nixpkgs.nix # import <nixpkgs> {}
 , compiler ? "default"
 }:
 let
-  inherit (nixpkgs) pkgs;
-
-  haskellPackages = if compiler == "default"
-                      then pkgs.haskellPackages
-                      else pkgs.haskell.packages.${compiler};
-
   sources = {
     tasty-wai = import ./nix/tasty-wai.nix;
     waarg = import ./nix/waargonaut.nix;
@@ -15,16 +9,40 @@ let
 
   waarg-deps = import "${sources.waarg}/waargonaut-deps.nix";
 
-  modifiedHaskellPackages = haskellPackages.override (old: {
-    overrides = pkgs.lib.composeExtensions
-      (old.overrides or (_: _: {}))
-      (self: super: (waarg-deps pkgs self super) // {
-        tasty-wai = self.callCabal2nix "tasty-wai" sources.tasty-wai {};
-        waargonaut = self.callCabal2nix "waargonaut" sources.waarg {};
+  course-overlay = self: super: {
+    haskellPackages = super.haskellPackages.override (old: {
+      overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: {})) (hself: hsuper: {
+        tasty-wai = hself.callCabal2nix "tasty-wai" sources.tasty-wai {};
+        waargonaut = hself.callCabal2nix "waargonaut" sources.waarg {};
       });
-  });
+    });
+  };
 
-  drv = modifiedHaskellPackages.callPackage ./applied-fp-course.nix {};
+  pkgs = import nixpkgs {
+    overlays = [ waarg-deps course-overlay ];
+  };
+
+  haskellPackages = if compiler == "default"
+                      then pkgs.haskellPackages
+                      else pkgs.haskell.packages.${compiler};
+
+  # sources = {
+  #   tasty-wai = import ./nix/tasty-wai.nix;
+  #   waarg = import ./nix/waargonaut.nix;
+  # };
+
+  # waarg-deps = import "${sources.waarg}/waargonaut-deps.nix";
+
+  # modifiedHaskellPackages = haskellPackages.override (old: {
+  #   overrides = pkgs.lib.composeExtensions
+  #     (old.overrides or (_: _: {}))
+  #     (self: super: (waarg-deps self super) // {
+  #       tasty-wai = self.callCabal2nix "tasty-wai" sources.tasty-wai {};
+  #       waargonaut = self.callCabal2nix "waargonaut" sources.waarg {};
+  #     });
+  # });
+
+  drv = haskellPackages.callPackage ./applied-fp-course.nix {};
 
 in
   drv

--- a/default.nix
+++ b/default.nix
@@ -1,46 +1,14 @@
-{ nixpkgs ? import ./nix/nixpkgs.nix # import <nixpkgs> {}
+{ nixpkgs ? import ./nix/nixpkgs.nix
 , compiler ? "default"
 }:
 let
-  sources = {
-    tasty-wai = import ./nix/tasty-wai.nix;
-    waarg = import ./nix/waargonaut.nix;
-  };
-
-  waarg-deps = import "${sources.waarg}/waargonaut-deps.nix";
-
-  course-overlay = self: super: {
-    haskellPackages = super.haskellPackages.override (old: {
-      overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: {})) (hself: hsuper: {
-        tasty-wai = hself.callCabal2nix "tasty-wai" sources.tasty-wai {};
-        waargonaut = hself.callCabal2nix "waargonaut" sources.waarg {};
-      });
-    });
-  };
-
   pkgs = import nixpkgs {
-    overlays = [ waarg-deps course-overlay ];
+    overlays = (import ./course-overlays.nix);
   };
 
   haskellPackages = if compiler == "default"
                       then pkgs.haskellPackages
                       else pkgs.haskell.packages.${compiler};
-
-  # sources = {
-  #   tasty-wai = import ./nix/tasty-wai.nix;
-  #   waarg = import ./nix/waargonaut.nix;
-  # };
-
-  # waarg-deps = import "${sources.waarg}/waargonaut-deps.nix";
-
-  # modifiedHaskellPackages = haskellPackages.override (old: {
-  #   overrides = pkgs.lib.composeExtensions
-  #     (old.overrides or (_: _: {}))
-  #     (self: super: (waarg-deps self super) // {
-  #       tasty-wai = self.callCabal2nix "tasty-wai" sources.tasty-wai {};
-  #       waargonaut = self.callCabal2nix "waargonaut" sources.waarg {};
-  #     });
-  # });
 
   drv = haskellPackages.callPackage ./applied-fp-course.nix {};
 

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/nixos/nixpkgs-channels.git",
+  "rev": "235487585edef271b191ac242be05f4d56f0be0c",
+  "date": "2019-02-24T11:36:26+01:00",
+  "sha256": "1x0xa6jrg4259fmrq35pnb0m1kffqqfii96dgxfs3rc4f843h77z",
+  "fetchSubmodules": true
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,11 @@
+let
+  hostNix = import <nixpkgs> {};
+  nixpkgsPin = hostNix.pkgs.lib.importJSON ./nixpkgs.json;
+
+  pinnedPkgs = hostNix.pkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo  = "nixpkgs-channels";
+    inherit (nixpkgsPin) rev sha256;
+  };
+in
+  pinnedPkgs

--- a/nix/tasty-wai.json
+++ b/nix/tasty-wai.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/qfpl/tasty-wai",
-  "rev": "17ae906f318a222eb30a22b6b334399a0ca436a9",
-  "date": "2018-12-04T14:31:04+10:00",
-  "sha256": "16j3qbpwxbl4n2pvck91k6gz2541pkfdpxn4l47nf1s9jx9yaa7f",
+  "rev": "1e65232f9c3b9c7293c81929fdebcda32a93b3c1",
+  "date": "2019-01-09T08:40:28+10:00",
+  "sha256": "1i2qh6kd76vkpbq0hjj21jwkfxn0ws750z10g2d6hvc7pjl0fz80",
   "fetchSubmodules": true
 }

--- a/nix/waargonaut.json
+++ b/nix/waargonaut.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/qfpl/waargonaut",
-  "rev": "7d868c5ca568797345cee762a499488227238b1f",
-  "date": "2018-11-29T12:55:15+10:00",
-  "sha256": "1hr0iyzcamgknsx4830rzvfxy6ykslnalfvbxb6k7h8ywkd2zzc2",
+  "rev": "984b428bdd7489f0763a665394680021bb9fee2d",
+  "date": "2019-02-22T15:09:51+10:00",
+  "sha256": "11iiy11sj7m9gf1dwcxxxq3pwmgrzjgpxh0b23z7bm7gdhglccvl",
   "fetchSubmodules": true
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,19 +1,10 @@
-{ compiler ? "default"
+{ nixpkgs ? import ./nix/nixpkgs.nix
+, compiler ? "default"
 }:
 let
-  inherit (import <nixpkgs> {}) fetchFromGitHub;
-
-  nixpkgs = fetchFromGitHub {
-    owner  = "NixOS";
-    repo   = "nixpkgs-channels";
-    rev    = "4f3446f29910d21eb0fb942bd03091b089cdad63";
-    sha256 = "0dqjkhhhckp881mns69qxn4dngcykal1gqrpaf9qy2vja4i41ay5";
-  };
-
   pkgs = import nixpkgs {};
-
   # Grab our course derivation
-  course = import ./. { nixpkgs = pkgs; inherit compiler; };
+  course = import ./. { inherit nixpkgs compiler; };
 
   # Override the basic derivation so we can have a more fully feature
   # environment for hacking on the course material

--- a/src/Level04/Core.hs
+++ b/src/Level04/Core.hs
@@ -26,6 +26,7 @@ import           Data.Either                        (Either (Left, Right),
 import           Data.Semigroup                     ((<>))
 import           Data.Text                          (Text)
 import           Data.Text.Encoding                 (decodeUtf8)
+import           Data.Text.Lazy.Encoding            (encodeUtf8)
 
 import           Database.SQLite.SimpleErrors.Types (SQLiteResponse)
 
@@ -105,8 +106,8 @@ resp200Json
   -> a
   -> Response
 resp200Json e =
-  mkResponse status200 JSON .
-  E.simplePureEncodeNoSpaces e
+  mkResponse status200 JSON . encodeUtf8 .
+  E.simplePureEncodeTextNoSpaces e
 
 -- |
 app

--- a/src/Level05/Core.hs
+++ b/src/Level05/Core.hs
@@ -26,6 +26,7 @@ import           Data.Monoid                        ((<>))
 
 import           Data.Text                          (Text)
 import           Data.Text.Encoding                 (decodeUtf8)
+import           Data.Text.Lazy.Encoding            (encodeUtf8)
 
 import           Waargonaut.Encode                  (Encoder')
 import qualified Waargonaut.Encode                  as E
@@ -119,8 +120,8 @@ resp200Json
   -> a
   -> Response
 resp200Json e =
-  resp200 JSON .
-  E.simplePureEncodeNoSpaces e
+  resp200 JSON . encodeUtf8 .
+  E.simplePureEncodeTextNoSpaces e
 
 -- |
 

--- a/src/Level06/Conf/File.hs
+++ b/src/Level06/Conf/File.hs
@@ -12,7 +12,7 @@ import           Control.Exception          (try)
 
 import qualified Data.Attoparsec.ByteString as AB
 
-import           Waargonaut                 (Json, parseWaargonaut)
+import           Waargonaut                 (Json)
 import qualified Waargonaut.Decode          as D
 import           Waargonaut.Decode.Error    (DecodeError (ParseFailed))
 
@@ -45,8 +45,5 @@ parseJSONConfigFile
   -> AppM ConfigError PartialConf
 parseJSONConfigFile =
   error "parseJSONConfigFile not implemented"
-  where
-    parseFunc :: ByteString -> Either DecodeError Json
-    parseFunc = first (ParseFailed . pack . show) . AB.parseOnly parseWaargonaut
 
 -- Go to 'src/Level06/Conf.hs' next.

--- a/src/Level06/Core.hs
+++ b/src/Level06/Core.hs
@@ -29,6 +29,7 @@ import           Data.Monoid                        ((<>))
 
 import           Data.Text                          (Text)
 import           Data.Text.Encoding                 (decodeUtf8)
+import           Data.Text.Lazy.Encoding            (encodeUtf8)
 
 import           Database.SQLite.SimpleErrors.Types (SQLiteResponse)
 
@@ -115,8 +116,8 @@ resp200Json
   -> a
   -> Response
 resp200Json e =
-  resp200 JSON .
-  E.simplePureEncodeNoSpaces e
+  resp200 JSON . encodeUtf8 .
+  E.simplePureEncodeTextNoSpaces e
 
 -- | Now that we have our configuration, pass it where it needs to go.
 app

--- a/src/Level07/Conf/File.hs
+++ b/src/Level07/Conf/File.hs
@@ -1,21 +1,18 @@
 module Level07.Conf.File where
 
-import           Data.ByteString            (ByteString)
-import qualified Data.ByteString.Char8      as LBS
+import           Data.ByteString       (ByteString)
+import qualified Data.ByteString.Char8 as LBS
 
-import           Data.Text                  (pack)
+import           Data.Text             (pack)
 
-import           Data.Bifunctor             (first)
+import           Data.Bifunctor        (first)
 
-import qualified Data.Attoparsec.ByteString as AB
+import           Waargonaut.Attoparsec (pureDecodeAttoparsecByteString)
 
-import           Waargonaut                 (Json, parseWaargonaut)
-import qualified Waargonaut.Decode          as D
-import           Waargonaut.Decode.Error    (DecodeError (ParseFailed))
+import           Control.Exception     (try)
 
-import           Control.Exception          (try)
-
-import           Level07.Types              (ConfigError (..), PartialConf, partialConfDecoder)
+import           Level07.Types         (ConfigError (..), PartialConf,
+                                        partialConfDecoder)
 
 -- Doctest setup section
 -- $setup
@@ -41,6 +38,6 @@ parseJSONConfigFile
   :: FilePath
   -> IO ( Either ConfigError PartialConf )
 parseJSONConfigFile fp =
-  (>>= first BadConfFile . doDecode) <$> readConfFile fp
+  (first BadConfFile . runDecode =<<) <$> readConfFile fp
   where
-    doDecode = D.pureDecodeFromByteString AB.parseOnly partialConfDecoder
+    runDecode = pureDecodeAttoparsecByteString partialConfDecoder

--- a/src/Level07/Conf/File.hs
+++ b/src/Level07/Conf/File.hs
@@ -43,7 +43,4 @@ parseJSONConfigFile
 parseJSONConfigFile fp =
   (>>= first BadConfFile . doDecode) <$> readConfFile fp
   where
-    doDecode = D.runPureDecode partialConfDecoder parseFunc . D.mkCursor
-
-    parseFunc :: ByteString -> Either DecodeError Json
-    parseFunc = first (ParseFailed . pack . show) . AB.parseOnly parseWaargonaut
+    doDecode = D.pureDecodeFromByteString AB.parseOnly partialConfDecoder

--- a/src/Level07/Responses.hs
+++ b/src/Level07/Responses.hs
@@ -7,6 +7,8 @@ import           Network.HTTP.Types         (Status, hContentType, status200,
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
+import           Data.Text.Lazy.Encoding    (encodeUtf8)
+
 import           Waargonaut.Encode          (Encoder')
 import qualified Waargonaut.Encode          as E
 
@@ -55,5 +57,5 @@ resp200Json
   -> a
   -> Response
 resp200Json e =
-  resp200 JSON .
-  E.simplePureEncodeNoSpaces e
+  resp200 JSON . encodeUtf8 .
+  E.simplePureEncodeTextNoSpaces e

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,12 @@
 resolver: lts-12.21
 extra-deps:
-- tasty-wai-0.1.0.1
-- waargonaut-0.4.2.0
+- tasty-wai-0.1.1.0
+- waargonaut-0.6.0.0
 - digit-0.7
 - hoist-error-0.2.1.0
 - hw-json-0.9.0.1
 - hw-parser-0.1.0.0
 - natural-0.3.0.3
 - tagged-0.8.6
-- generics-sop-0.3.2.0
+- generics-sop-0.4.0.1
 - witherable-0.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,5 +8,6 @@ extra-deps:
 - hw-parser-0.1.0.0
 - natural-0.3.0.3
 - tagged-0.8.6
+- sop-core-0.4.0.0
 - generics-sop-0.4.0.1
 - witherable-0.2


### PR DESCRIPTION
Move the pinned nixpkgs to a nix file to be consistent with other qfpl repos, update the pin to a more recent 18.09 revision.

Upgrade `tasty-wai` and `waargonaut` to recent versions. The former is minor but the latter has significant usability improvements.

The lessons have been updated where appropriate. 